### PR TITLE
Add supported Linux build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,13 @@ name: Build
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ] # FIXME (aliddell): this is temporary for testing
 
 jobs:
   windows-build:
     name: "Build on Windows with eGrabber SDK"
-    runs-on: [ self-hosted, egrabber ]
+    runs-on: [ self-hosted, windows, egrabber ]
 
     permissions:
       actions: write
@@ -50,16 +52,43 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: Release binaries
+          name: windows-latest Release binaries
           path: ${{github.workspace}}/*.zip
 
-  unsupported-build:
-    name: "Build on Mac and Ubuntu"
-    strategy:
-      matrix:
-        platform: [ "ubuntu-latest", "macos-latest" ]
+  linux-build:
+    name: "Build on Ubuntu"
+    runs-on: [ self-hosted, linux, egrabber ]
 
-    runs-on: ${{ matrix.platform }}
+    permissions:
+      actions: write
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.10.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Configure
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: |
+          cmake --build ${{github.workspace}}/build --config Release
+          cpack --config ${{github.workspace}}/build/CPackConfig.cmake -C Release -G ZIP
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ubuntu-latest Release binaries
+          path: ${{github.workspace}}/*.zip
+
+  mac-build:
+    name: "Build on Mac"
+    runs-on: macos-latest
 
     permissions:
       actions: write
@@ -84,5 +113,5 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{matrix.platform}} Release binaries
+          name: macos-latest Release binaries
           path: ${{github.workspace}}/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ] # FIXME (aliddell): this is temporary for testing
 
 jobs:
   windows-build:
@@ -56,7 +54,7 @@ jobs:
           path: ${{github.workspace}}/*.zip
 
   linux-build:
-    name: "Build on Ubuntu"
+    name: "Build on Ubuntu with eGrabber SDK"
     runs-on: [ self-hosted, linux, egrabber ]
 
     permissions:

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -13,7 +13,11 @@ env:
 
 jobs:
   test:
-    runs-on: [ self-hosted, windows, egrabber ]  # Vieworks hardware only present on Windows runner
+    runs-on:
+      group: Camera  # Vieworks hardware only present on runners in this group
+      labels:
+        - self-hosted
+        - egrabber
     permissions:
       actions: write
 

--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   test:
-    runs-on: [ self-hosted, egrabber ]
+    runs-on: [ self-hosted, windows, egrabber ]  # Vieworks hardware only present on Windows runner
     permissions:
       actions: write
 


### PR DESCRIPTION
- Builds Linux driver on a self-hosted runner with eGrabber SDK.
- Restricts PR test job to run on Ghanima only.